### PR TITLE
Fix executor not retrying on receive errors

### DIFF
--- a/memcached/src/main/scala/zio/memcached/MemcachedExecutor.scala
+++ b/memcached/src/main/scala/zio/memcached/MemcachedExecutor.scala
@@ -178,7 +178,6 @@ object MemcachedExecutor {
         .via(RespValue.decoder)
         .collectSome
         .foreach(response => resQueue.take.flatMap(_.succeed(response)))
-        .orDie
 
     /**
      * Opens a connection to the server and launches send and receive operations. All failures are retried by opening a


### PR DESCRIPTION
## Summary
- allow connection errors in the receive loop to propagate instead of dying

## Testing
- `sbt test` *(fails: `sbt: command not found`)*