### PR TITLE
Fix typo in StringUtf8CodecSpec

### DIFF
--- a/memcached/src/test/scala/zio/memcached/codec/StringUtf8CodecSpec.scala
+++ b/memcached/src/test/scala/zio/memcached/codec/StringUtf8CodecSpec.scala
@@ -36,7 +36,7 @@ object StringUtf8CodecSpec extends BaseSpec {
             result <- get[String](key)
           } yield assert(result)(isSome(equalTo("value")))
         },
-        test("emtpy string") {
+        test("empty string") {
           for {
             key    <- uuid
             result <- get[String](key)


### PR DESCRIPTION
## Summary
- fix a small typo in StringUtf8CodecSpec test description

## Testing
- `./sbt test:compile` *(fails: Could not download and verify the launcher)*